### PR TITLE
fix(less): fix variables for import paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,15 @@ Those dependencies will be installed automatically by npm:
 [less-plugin-remcalc](https://github.com/ovh-ux/less-plugin-remcalc) is needed to compile the LESS import.
 
 ```less
-@import "./node_modules/ovh-ui-kit-bs/src/ovh-ui-kit-bs";
+/* Required */
 
-// Paths of dependencies
+// Paths of the dependencies
 @bs-path: "./node_modules/bootstrap";
 @oui-path: "./node_modules/ovh-ui-kit";
+
+@import "./node_modules/ovh-ui-kit-bs/src/ovh-ui-kit-bs";
+
+/* Optional */
 
 // Bootstrap fonts
 @icon-font-path: "./node_modules/ovh-ui-kit-bs/dist/fonts/";

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ovh-ui-kit-bs",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A bootstrap theme for the OVH managers, based on ovh-ui-kit.",
   "author": "OVH SAS",
   "license": "BSD-3-Clause",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ovh-ui-kit-bs",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A bootstrap theme for the OVH managers, based on ovh-ui-kit.",
   "author": "OVH SAS",
   "license": "BSD-3-Clause",
@@ -12,8 +12,8 @@
     "copy:fonts": "cpx \"node_modules/ovh-ui-kit/packages/oui-typography/fonts/**/*\" \"dist/fonts\"",
     "copy:icons": "cpx \"node_modules/ovh-ui-kit/dist/icons/*\" \"dist/icons\"",
     "copy:glyphicons": "cpx \"node_modules/bootstrap/fonts/*\" \"dist/fonts\"",
-    "less": "lessc --remcalc --clean-css \"src/ovh-ui-kit-bs.less\" \"dist/ovh-ui-kit-bs.css\"",
-    "less:debug": "lessc --remcalc \"src/ovh-ui-kit-bs.less\" \"dist/ovh-ui-kit-bs.css\"",
+    "less": "lessc --remcalc --clean-css \"src/_dist.less\" \"dist/ovh-ui-kit-bs.css\"",
+    "less:debug": "lessc --remcalc \"src/_dist.less\" \"dist/ovh-ui-kit-bs.css\"",
     "start": "npm run build"
   },
   "dependencies": {

--- a/src/_dist.less
+++ b/src/_dist.less
@@ -1,0 +1,5 @@
+// REQUIRED: Paths of the dependencies
+@bs-path: "../node_modules/bootstrap";
+@oui-path: "../node_modules/ovh-ui-kit";
+
+@import "ovh-ui-kit-bs";

--- a/src/utils/_settings.less
+++ b/src/utils/_settings.less
@@ -1,7 +1,3 @@
-// Paths of dependencies
-@bs-path: "../node_modules/bootstrap";
-@oui-path: "../node_modules/ovh-ui-kit";
-
 // OVH UI icons & fonts
 @oui-icon-dist-folder: "./icons";
 @oui-font-source-sans-pro-folder: "./fonts/source-sans-pro";


### PR DESCRIPTION
It seems that we can't override a variable for an import path, set in a file imported (__settings.less_), if you're in a file importing the global file (_ovh-ui-kit-bs.less_). 
Even by putting the definition afterwards.

I tried many things to keep a default value in the source files, but: http://lesscss.org/features/#variables-feature-default-variables.

So, to meet the needs of each manager, the paths of the dependencies must be set when you import _ovh-ui-kit-bs.less_.