### PR TITLE
fix(dropdown): leave BS standard z-index

### DIFF
--- a/src/bootstrap/dropdown.less
+++ b/src/bootstrap/dropdown.less
@@ -69,7 +69,6 @@
 .dropdown-menu {
     #oui > .action-menu-base();
 
-    z-index: @oui-dropdown-zindex;
     max-width: @oui-dropdown-max-width;
     background-color: @oui-dropdown-background-color;
     border: @oui-dropdown-border-width @oui-dropdown-border-color solid;


### PR DESCRIPTION
Removed z-index from BS 3 as it prevents the dropdown to work on touch-enabled environment