### PR TITLE
fix(navs): remove border-bottom on nav-tabs

### DIFF
--- a/src/bootstrap/navs.less
+++ b/src/bootstrap/navs.less
@@ -28,6 +28,7 @@
 
         > a {
             margin-right: 0;
+            border-bottom: none;
             color: @oui-color-zodiac;
             cursor: pointer;
 

--- a/src/bootstrap/navs.less
+++ b/src/bootstrap/navs.less
@@ -15,6 +15,7 @@
     padding-right: @grid-gutter-width;
 
     > li {
+        margin: 0;
         margin-right: 2px;
 
         &::after {
@@ -28,12 +29,11 @@
 
         > a {
             margin-right: 0;
-            border-bottom: none;
+            border: none;
             color: @oui-color-zodiac;
             cursor: pointer;
 
             &:hover, &:focus {
-                border-bottom: 0;
                 border-color: transparent;
             }
         }
@@ -48,7 +48,7 @@
             > a {
                 &, &:hover, &:focus {
                     background-color: transparent;
-                    border: 0;
+                    border: none;
                     color: @oui-link-font-color;
                     font-weight: bold;
                 }
@@ -61,8 +61,6 @@
                 left: 0;
                 width: 100%;
             }
-
-            > a { border: none; }
 
             &.open > a { font-weight: bold; }
         }


### PR DESCRIPTION
Remove `border-bottom` on `nav-tabs` to avoid dancing tabs on hover (occurs only when there is 2 tabs)