### PR TITLE
fix: use the right codeowners syntax

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@AxelPeter @FredericEspiau @euhmeuh @JeremyDec
+*    @AxelPeter @FredericEspiau @euhmeuh @JeremyDec


### PR DESCRIPTION
## Use the right CODEOWNERS syntax

### Description of the Change

cf09c9f - fix: use the right codeowners syntax

/cc @jleveugle @Jisay @frenautvh @cbourgois