### PR TITLE
build(dev-deps): upgrade rimraf to v3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "less-plugin-remcalc": "^0.1.0",
     "npm-run-all": "^4.1.5",
     "opn-cli": "^5.0.0",
-    "rimraf": "^2.7.1",
+    "rimraf": "^3.0.2",
     "stylelint": "^13.2.1",
     "stylelint-config-standard": "^19.0.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3101,10 +3101,10 @@ rimraf@2.6.3, rimraf@^2.6.1:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
-  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 


### PR DESCRIPTION
## Upgrade `rimraf`

### Description of the Change

#### ⬆️ Upgrade

1f16728 - build(dev-deps): upgrade rimraf to v3.0.2

uses: `yarn upgrade-interactive --latest rimraf`
- rimraf@3.0.2

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>
