### PR TITLE
build(dev-deps): upgrade stylelint-config-standard to v20.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "opn-cli": "^5.0.0",
     "rimraf": "^3.0.2",
     "stylelint": "^13.2.1",
-    "stylelint-config-standard": "^19.0.0"
+    "stylelint-config-standard": "^20.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3100,10 +3100,10 @@ stylelint-config-recommended@^3.0.0:
   resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-3.0.0.tgz#e0e547434016c5539fe2650afd58049a2fd1d657"
   integrity sha512-F6yTRuc06xr1h5Qw/ykb2LuFynJ2IxkKfCMf+1xqPffkxh0S09Zc902XCffcsw/XMFq/OzQ1w54fLIDtmRNHnQ==
 
-stylelint-config-standard@^19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-19.0.0.tgz#66f0cf13f33b8a9e34965881493b38fc1313693a"
-  integrity sha512-VvcODsL1PryzpYteWZo2YaA5vU/pWfjqBpOvmeA8iB2MteZ/ZhI1O4hnrWMidsS4vmEJpKtjdhLdfGJmmZm6Cg==
+stylelint-config-standard@^20.0.0:
+  version "20.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-20.0.0.tgz#06135090c9e064befee3d594289f50e295b5e20d"
+  integrity sha512-IB2iFdzOTA/zS4jSVav6z+wGtin08qfj+YyExHB3LF9lnouQht//YyB0KZq9gGz5HNPkddHOzcY8HsUey6ZUlA==
   dependencies:
     stylelint-config-recommended "^3.0.0"
 


### PR DESCRIPTION
## Upgrade stylelint-config-standard to v20.0.0

### Description of the Change

#### 👷 Build

uses: `$ yarn upgrade-interactive --latest stylelint-config-standard`
- stylelint-config-standard@20.0.0

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>