### PR TITLE
fix(form): remove margin-bottom for control-label helper

### DIFF
--- a/src/less/bootstrap/form.less
+++ b/src/less/bootstrap/form.less
@@ -273,6 +273,10 @@ input[type="checkbox"] { margin: @padding-base-vertical 0 0 0; }
 }
 
 // Feedbacks
+.control-label {
+  margin-bottom: 0px;
+}
+
 .form-control-feedback {
   width: @oui-input-overlay-size;
   height: @oui-input-overlay-size;


### PR DESCRIPTION
## Form - Remove margin-bottom for control-label helper

### Description of the Change

#### :bug: Big Fix

640f92f  - fix(form): remove margin-bottom for control-label helper

#### :link: Relates

Relates to:
* https://github.com/ovh/ovh-ui-kit/blob/131b2b52958090634261acee10585b76537056e5/packages/components/field/src/less/field.less#L13
* https://getbootstrap.com/docs/3.4/css/#forms-control-validation

#### :camera_flash: Screenshot

![screenshot-control-label](https://user-images.githubusercontent.com/428384/87777644-28fbe580-c82a-11ea-9dd4-36e2ec72fa3b.png)

Expected results:
https://ovh.github.io/ovh-ui-kit/?path=/story/design-system-components-field-webcomponent--default

### Benefits

Prevent having margins on the `.control-label` element.

### Possible Drawbacks

None.

### Applicable Issues

None.